### PR TITLE
OA論文数のカウントがおかしくなっているようでしたので修正してみました

### DIFF
--- a/dashboard_template.html
+++ b/dashboard_template.html
@@ -825,7 +825,6 @@
                 let works = worksData.results || [];
                 
                 const totalWorks = worksData.meta?.count || 0;
-                const oaCount = works.filter(w => w.open_access?.is_oa).length;
                 const avgCitations = works.length > 0 
                     ? (works.reduce((sum, w) => sum + (w.cited_by_count || 0), 0) / works.length).toFixed(1)
                     : 0;
@@ -836,6 +835,7 @@
                 // OA論文の年次推移データを取得
                 const yearlyOaData = await fetchOpenAlexData('/works', { filter: filterStr + ',open_access.is_oa:true', 'group_by': 'publication_year' });
                 const yearlyOaTrend = (yearlyOaData.group_by || []).map(item => ({ year: parseInt(item.key), count: item.count })).sort((a, b) => a.year - b.year);
+                const oaCount = yearlyOaData.meta?.count || 0;
 
                 const topicData = await fetchOpenAlexData('/works', { filter: filterStr, 'group_by': 'topics.id' });
                 const topTopics = (topicData.group_by || []).slice(0, 10).map(item => ({ topic: item.key_display_name || 'Unknown', count: item.count }));


### PR DESCRIPTION
現状では，ダッシュボード上部の「OA論文数」がリスト表示されている200件に含まれている分しかカウントされていないようでした。ですので，件数が総論文数が200件を超える表示ではOA論文数がおかしくなっていました。以下の修正をしてみました。

-  旧828行目を削除：200件からのカウントを廃止
-  新838行目を追加：全件でカウント
 
 私の環境ではこの修正で200件を超える場合でも「OA論文数」が正常にカウントされるようになりました。 ご確認下さい。 

 ---
 2026年は総論文数が200件以下なので，OA論文数のカウントも正常です。右の円グラフとも一致しています。 
<img width="1421" height="985" alt="20260210_OACountMod_01_2026" src="https://github.com/user-attachments/assets/0ba54a95-e9b2-4a6c-b95b-fd6c1ee8fc60" />

2025年は総論文数が200件を超えているので，OA論文数のカウントが追いついていません。右の円グラフとOA数に差が出ています。円グラフ上はOAは747件でした。
<img width="1395" height="980" alt="20260210_OACountMod_02_2025" src="https://github.com/user-attachments/assets/762278dd-800e-4539-88f2-79ba5a371619" />

修正後のコードでは以下のようになりました。
<img width="1394" height="956" alt="2026-02-10 (2)" src="https://github.com/user-attachments/assets/4840f81d-1f75-4360-9e5d-440757a9fd42" />

